### PR TITLE
integrate HuggingFace embeddings and re-ingest product data

### DIFF
--- a/Week_9/requirements.txt
+++ b/Week_9/requirements.txt
@@ -14,3 +14,7 @@ psycopg2-binary>=2.9       # you already use this in scripts; ok to keep both
 pgvector>=0.3
 
 SQLAlchemy>=2.0            # sometimes required by langchain-postgres
+
+# Hugging Face embeddings
+torch
+sentence-transformers

--- a/Week_9/scripts/constants.py
+++ b/Week_9/scripts/constants.py
@@ -6,16 +6,16 @@ API keys and secrets should remain in the .env file, not here.
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
-# Load environment variables
+# ---------------- Load environment ----------------
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 load_dotenv(os.path.join(BASE_DIR, ".env"))
 
-# Database URL (from .env)
+# ---------------- Database ----------------
 DATABASE_URL_WEEK8 = os.getenv("DATABASE_URL_WEEK8")
 
+# ---------------- Models ----------------
 # Embedding and Chat Models
-EMBEDDING_MODEL = "text-embedding-3-small"
+EMBEDDING_MODEL = "sentence-transformers/all-MiniLM-L6-v2"  # HuggingFace model
 CHAT_MODEL = "gpt-4o-mini"
 
 # Temperature for GPT responses
@@ -30,3 +30,15 @@ PRODUCT_TABLE = "products"
 # Text splitting config
 CHUNK_SIZE = 500
 CHUNK_OVERLAP = 50
+
+# ---------------- Embeddings ----------------
+# HuggingFace Embeddings (default)
+from langchain_huggingface import HuggingFaceEmbeddings
+
+
+HF_EMBEDDINGS = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+
+# If you want to switch to OpenAI later, uncomment below:
+# from langchain_openai import OpenAIEmbeddings
+# OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+# OPENAI_EMBEDDINGS = OpenAIEmbeddings(model=EMBEDDING_MODEL, openai_api_key=OPENAI_API_KEY)

--- a/Week_9/scripts/embedding.py
+++ b/Week_9/scripts/embedding.py
@@ -1,4 +1,3 @@
-# scripts/ingest_embeddings.py
 """
 Generate embeddings for product data and store them in PGVector.
 Skips creation if embeddings already exist in the database.
@@ -9,37 +8,35 @@ import os
 from typing import List, Dict
 from dotenv import load_dotenv
 
-from langchain_openai import OpenAIEmbeddings
+from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.documents import Document
 
 from data_loader import load_products
-from constants import EMBEDDING_MODEL, CHUNK_SIZE, CHUNK_OVERLAP
+from constants import CHUNK_SIZE, CHUNK_OVERLAP
 
 # ---------------- Setup ----------------
 load_dotenv()
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    raise RuntimeError("OPENAI_API_KEY not set in environment or .env")
-
 
 def embed_and_store(
-    products: List[Dict], collection_name: str = "product_embeddings"
+    products: List[Dict], collection_name: str = "product_embeddings_hf"
 ) -> PGVector:
     """
-    Generate embeddings for product data and store them in PGVector.
+    Generate embeddings for product data using HuggingFace and store in PGVector.
     If embeddings already exist in the collection, skip creation.
     """
     db_url = os.getenv("DATABASE_URL_WEEK8")
     if not db_url:
         raise ValueError("DATABASE_URL_WEEK8 not found in environment variables")
 
-    logger.info("Initializing OpenAI embeddings...")
-    embeddings = OpenAIEmbeddings(model=EMBEDDING_MODEL, openai_api_key=OPENAI_API_KEY)
+    logger.info("Initializing HuggingFace embeddings...")
+    embeddings = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-MiniLM-L6-v2"
+    )
 
     # ---------------- Check if embeddings already exist ----------------
     vector_store = PGVector(

--- a/Week_9/scripts/rag_chain.py
+++ b/Week_9/scripts/rag_chain.py
@@ -1,5 +1,3 @@
-# scripts/rag_chain.py
-
 import logging
 import os
 import sys
@@ -9,13 +7,14 @@ if BASE_DIR not in sys.path:
     sys.path.insert(0, BASE_DIR)
 
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_openai import ChatOpenAI
+from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores.pgvector import PGVector
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain.schema import StrOutputParser
 
-from scripts.constants import CHAT_MODEL, CHAT_TEMPERATURE, EMBEDDING_MODEL
+from scripts.constants import CHAT_MODEL, CHAT_TEMPERATURE
 from prompts.system_prompt import SYSTEM_PROMPT
 from scripts.llm_cache import SQLAlchemyCache
 
@@ -24,18 +23,16 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    raise RuntimeError("OPENAI_API_KEY not set in environment or .env")
 
-
-def load_vector_store(collection_name: str = "product_embeddings") -> PGVector:
-    """Load existing PGVector embeddings from the database."""
+def load_vector_store(collection_name: str = "product_embeddings_hf") -> PGVector:
+    """Load existing PGVector embeddings (HuggingFace) from the database."""
     db_url = os.getenv("DATABASE_URL_WEEK8")
     if not db_url:
         raise ValueError("DATABASE_URL_WEEK8 not found in environment variables")
 
-    embeddings = OpenAIEmbeddings(model=EMBEDDING_MODEL, openai_api_key=OPENAI_API_KEY)
+    embeddings = HuggingFaceEmbeddings(
+        model_name="sentence-transformers/all-MiniLM-L6-v2"
+    )
 
     vector_store = PGVector(
         collection_name=collection_name,
@@ -73,13 +70,31 @@ _rag_chain = build_rag_chain(_vector_store)
 
 
 def answer_question(question: str) -> str:
-    """Return answer from cache if available, otherwise generate via RAG chain."""
-    cached_answer = SQLAlchemyCache.get(question)
-    if cached_answer:
-        return cached_answer
+    """
+    Return answer from cache if available, otherwise generate via RAG chain.
+    Skips cache if Flask app context is not available (for CLI testing).
+    """
+    try:
+        cached_answer = SQLAlchemyCache.get(question)
+        if cached_answer:
+            logger.info(f"[CACHE HIT] Question found in cache: {question}")
+            return cached_answer
+    except RuntimeError:
+        # Flask app context not available → skip cache
+        logger.info(
+            f"[CACHE SKIP] Running outside Flask context for question: {question}"
+        )
 
     answer = _rag_chain.invoke(question)
-    SQLAlchemyCache.set(question, answer)
+
+    try:
+        SQLAlchemyCache.set(question, answer)
+        logger.info(f"[CACHE SET] Storing answer for question: {question}")
+    except RuntimeError:
+        logger.info(
+            f"[CACHE SKIP] Could not store cache outside Flask context for question: {question}"
+        )
+
     return answer
 
 


### PR DESCRIPTION
## Day 2 - HuggingFace Embeddings Integration

### Changes Made
- Integrated HuggingFace `all-MiniLM-L6-v2` embeddings for retrieval.
- Updated `embedding.py` to use HuggingFaceEmbeddings instead of OpenAI.
- Created new collection `product_embeddings_hf` in PGVector.
- Refactored `rag_chain.py` to load HuggingFace-based embeddings.
- Re-ingested product data into the new collection.

### Outcome
- Retrieval pipeline now uses open-source embeddings (cost savings, no API dependency).
- Cache mechanism continues to work with HuggingFace embeddings.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/865b6b82-58e2-4b98-8945-fd0109d772a8" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/51a5ff61-e81c-4978-ae61-090a130c4380" />

